### PR TITLE
add icon for Metro

### DIFF
--- a/app/src/main/res/xml/grayscale_icon_map.xml
+++ b/app/src/main/res/xml/grayscale_icon_map.xml
@@ -379,6 +379,7 @@
     <icon drawable="@drawable/youtube_vanced" package="com.vanced.android.youtube" name="YouTube Vanced" />
     <icon drawable="@drawable/youtube_vanced_manager" package="com.vanced.manager" name="YouTube Vanced Manager" />
     <icon drawable="@drawable/retro_music" package="code.name.monkey.retromusic" name="Retro Music" />
+    <icon drawable="@drawable/retro_music" package="io.github.muntashirakon.Music" name="Metro" />
     <icon drawable="@drawable/auxio" package="org.oxycblt.auxio" name="Auxio" />
     <icon drawable="@drawable/syncthing" package="com.nutomic.syncthingandroid" name="Syncthing" />
     <icon drawable="@drawable/camera" package="net.sourceforge.opencamera" name="Open Camera" />


### PR DESCRIPTION
this will use `@drawable/retro_music` as the icon for `io.github.muntashirakon.Music`, which itself uses the same icon as `code.name.monkey.retromusic`